### PR TITLE
Add sample tactical site

### DIFF
--- a/new_site/index.html
+++ b/new_site/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tactical Manager</title>
+  <link rel="stylesheet" href="styles/global.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+  <header class="site-header">
+    <h1>Tactical Manager</h1>
+    <nav class="main-nav">
+      <a href="pages/dashboard.html">Dashboard</a>
+    </nav>
+  </header>
+  <main class="site-main">
+    <p>Bienvenue sur votre nouvelle plateforme tactique.</p>
+  </main>
+  <footer class="site-footer">
+    <small>&copy; 2025 Tactical Manager</small>
+  </footer>
+</body>
+</html>

--- a/new_site/pages/dashboard.html
+++ b/new_site/pages/dashboard.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dashboard</title>
+  <link rel="stylesheet" href="../styles/global.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+  <header>
+    <h1><i class="fas fa-tachometer-alt"></i> Dashboard</h1>
+  </header>
+  <main>
+    <section class="info-block">
+      <h2>Statistiques</h2>
+      <div class="stats-grid">
+        <div class="stat">
+          <span class="value">9</span>
+          <span class="label">Agents actifs</span>
+        </div>
+        <div class="stat">
+          <span class="value">7</span>
+          <span class="label">Missions en cours</span>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <a href="../index.html">Accueil</a>
+  </footer>
+</body>
+</html>

--- a/new_site/server.js
+++ b/new_site/server.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 4000;
+
+app.use(express.static(path.join(__dirname)));
+
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`New site running on port ${PORT}`);
+});

--- a/new_site/styles/global.css
+++ b/new_site/styles/global.css
@@ -1,0 +1,58 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;900&display=swap');
+
+:root {
+  --accent: #ffbf00;
+  --bg-dark: #0a0a0a;
+  --bg-medium: #111111;
+  --text-color: #ffbf00;
+  --card-bg: #181818;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Orbitron', sans-serif;
+  background: var(--bg-dark);
+  color: var(--text-color);
+  min-height: 100vh;
+}
+
+.site-header {
+  background: var(--bg-medium);
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.main-nav a {
+  color: var(--text-color);
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+.info-block {
+  padding: 1rem;
+}
+
+.stats-grid {
+  display: flex;
+  gap: 1rem;
+}
+
+.stat {
+  background: var(--card-bg);
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.value {
+  font-size: 2rem;
+  font-weight: 600;
+}
+
+.label {
+  display: block;
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- create a new demo folder `new_site`
- add minimal index and dashboard pages
- style the demo site
- include a simple Express server to serve the demo

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840a23072748328b1c1c36bd0095c0b