### PR TITLE
Simplify dataManager fetch helpers

### DIFF
--- a/scripts/dataManager.js
+++ b/scripts/dataManager.js
@@ -1,28 +1,19 @@
 // dataManager.js — version statique pour GitHub Pages
 
-export async function getSoldats() {
-  const res = await fetch('data/test/soldats.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des soldats');
-  return await res.json();
+// Utilitaire générique de chargement de données JSON de data/test
+async function fetchData(name) {
+  const res = await fetch(`data/test/${name}.json`);
+  if (!res.ok) throw new Error(`Erreur chargement ${name}`);
+  return res.json();
 }
 
-export async function getUnites() {
-  const res = await fetch('data/test/unites.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des unités');
-  return await res.json();
-}
+export const getSoldats = () => fetchData('soldats');
 
-export async function getMissions() {
-  const res = await fetch('data/test/missions.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des missions');
-  return await res.json();
-}
+export const getUnites = () => fetchData('unites');
 
-export async function getFormations() {
-  const res = await fetch('data/test/formations.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des formations');
-  return await res.json();
-}
+export const getMissions = () => fetchData('missions');
+
+export const getFormations = () => fetchData('formations');
 
 // Les fonctions de création, modification, suppression ne font rien en statique
 export async function createSoldat() { throw new Error('Non supporté en statique'); }

--- a/scripts/displayManager.js
+++ b/scripts/displayManager.js
@@ -1,5 +1,4 @@
 // Gestion de l’affichage dynamique (dashboard, alertes, etc.)
-import { fetchData } from './utils.js';
 import { getData, setData, addItem, updateItem, deleteItem } from './dataManager.js';
 import { showToast } from '../components/Toast.js';
 


### PR DESCRIPTION
## Summary
- add generic `fetchData` in `dataManager.js`
- rewrite the data loading functions using the new helper
- remove unused `fetchData` import from `displayManager.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6840b24b89408328b4236f854b40ff7a