### PR TITLE
Add .env config and expose runtime variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+PORT=3000
+ALLOWED_ORIGINS=https://votre-username.github.io,http://localhost:3000
+DATA_DIR=data/api

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 dist/
 data/prod/*.json
-.env

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
       </div>
     </div>
   </footer>
+  <script src="config.js"></script>
   <script src="scripts/main.js" type="module"></script>
 </body>
 </html>

--- a/new_site/server.js
+++ b/new_site/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const path = require('path');
 

--- a/render.yaml
+++ b/render.yaml
@@ -10,4 +10,6 @@ services:
       - key: PORT
         value: 3000
       - key: ALLOWED_ORIGINS
-        value: https://votre-username.github.io 
+        value: https://votre-username.github.io
+      - key: DATA_DIR
+        value: data/api

--- a/routes/alerts.js
+++ b/routes/alerts.js
@@ -4,9 +4,10 @@ const fs = require('fs').promises;
 const path = require('path');
 
 // Chemins des fichiers de données
-const SOLDATS_FILE = path.join(__dirname, '../data/api/soldats.json');
-const MISSIONS_FILE = path.join(__dirname, '../data/api/missions.json');
-const FORMATIONS_FILE = path.join(__dirname, '../data/api/formations.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '../data/api');
+const SOLDATS_FILE = path.join(DATA_DIR, 'soldats.json');
+const MISSIONS_FILE = path.join(DATA_DIR, 'missions.json');
+const FORMATIONS_FILE = path.join(DATA_DIR, 'formations.json');
 
 // Helper pour lire les données
 async function readData(filePath) {

--- a/routes/formations.js
+++ b/routes/formations.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const fs = require('fs').promises;
 const path = require('path');
 
-const DATA_FILE = path.join(__dirname, '../data/api/formations.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '../data/api');
+const DATA_FILE = path.join(DATA_DIR, 'formations.json');
 
 // Helper pour lire/écrire les données
 async function readData() {

--- a/routes/missions.js
+++ b/routes/missions.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const fs = require('fs').promises;
 const path = require('path');
 
-const DATA_FILE = path.join(__dirname, '../data/api/missions.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '../data/api');
+const DATA_FILE = path.join(DATA_DIR, 'missions.json');
 
 // Helper pour lire/écrire les données
 async function readData() {

--- a/routes/soldats.js
+++ b/routes/soldats.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const fs = require('fs').promises;
 const path = require('path');
 
-const DATA_FILE = path.join(__dirname, '../data/api/soldats.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '../data/api');
+const DATA_FILE = path.join(DATA_DIR, 'soldats.json');
 
 // Helper pour lire/écrire les données
 async function readData() {

--- a/routes/unites.js
+++ b/routes/unites.js
@@ -3,7 +3,8 @@ const router = express.Router();
 const fs = require('fs').promises;
 const path = require('path');
 
-const DATA_FILE = path.join(__dirname, '../data/api/unites.json');
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, '../data/api');
+const DATA_FILE = path.join(DATA_DIR, 'unites.json');
 
 // Helper pour lire/écrire les données
 async function readData() {

--- a/scripts/dataManager.js
+++ b/scripts/dataManager.js
@@ -1,25 +1,29 @@
 // dataManager.js — version statique pour GitHub Pages
 
 export async function getSoldats() {
-  const res = await fetch('data/test/soldats.json');
+  const base = window.CONFIG?.DATA_DIR || 'data/test';
+  const res = await fetch(`${base}/soldats.json`);
   if (!res.ok) throw new Error('Erreur lors de la récupération des soldats');
   return await res.json();
 }
 
 export async function getUnites() {
-  const res = await fetch('data/test/unites.json');
+  const base = window.CONFIG?.DATA_DIR || 'data/test';
+  const res = await fetch(`${base}/unites.json`);
   if (!res.ok) throw new Error('Erreur lors de la récupération des unités');
   return await res.json();
 }
 
 export async function getMissions() {
-  const res = await fetch('data/test/missions.json');
+  const base = window.CONFIG?.DATA_DIR || 'data/test';
+  const res = await fetch(`${base}/missions.json`);
   if (!res.ok) throw new Error('Erreur lors de la récupération des missions');
   return await res.json();
 }
 
 export async function getFormations() {
-  const res = await fetch('data/test/formations.json');
+  const base = window.CONFIG?.DATA_DIR || 'data/test';
+  const res = await fetch(`${base}/formations.json`);
   if (!res.ok) throw new Error('Erreur lors de la récupération des formations');
   return await res.json();
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -14,7 +14,8 @@ export function getEnv() {
  */
 export async function fetchData(name) {
   const env = getEnv();
-  const url = `/data/${env.toLowerCase()}/${name}.json`;
+  const baseDir = window.CONFIG?.DATA_DIR || `/data/${env.toLowerCase()}`;
+  const url = `${baseDir}/${name}.json`;
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error(`Erreur lors du chargement de ${url}`);

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const fs = require('fs').promises;
@@ -5,10 +6,15 @@ const path = require('path');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data/api');
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',')
+  : ['https://votre-username.github.io', 'http://localhost:3000'];
+app.locals.DATA_DIR = DATA_DIR;
 
 // Middleware
 app.use(cors({
-  origin: ['https://votre-username.github.io', 'http://localhost:3000'],
+  origin: allowedOrigins,
   methods: ['GET', 'POST', 'PUT', 'DELETE'],
   allowedHeaders: ['Content-Type']
 }));
@@ -33,6 +39,16 @@ app.use('/api/alerts', alertsRouter);
 // Route racine
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+// Expose runtime config to client
+app.get('/config.js', (req, res) => {
+  const config = {
+    PORT,
+    DATA_DIR,
+    ALLOWED_ORIGINS: allowedOrigins,
+  };
+  res.type('application/javascript').send(`window.CONFIG = ${JSON.stringify(config)};`);
 });
 
 // Health check endpoint


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- expose runtime config with `/config.js`
- read `DATA_DIR` in API routes
- reference `DATA_DIR` in client scripts
- update `render.yaml` with new env vars

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `node server.js` *(manual start to verify)*

------
https://chatgpt.com/codex/tasks/task_e_6843f54da79c8328acae8018dc5eaf67