### PR TITLE
Implement mission and formation management

### DIFF
--- a/scripts/formationsManager.js
+++ b/scripts/formationsManager.js
@@ -1,1 +1,98 @@
-export function initFormations() {} 
+import { getFormations } from './dataManager.js';
+import { showToast } from '../components/Toast.js';
+
+let formations = [];
+
+export async function initFormations() {
+  try {
+    formations = await getFormations();
+  } catch (e) {
+    console.error('Erreur chargement formations', e);
+    formations = [];
+  }
+  renderFormations();
+  const addBtn = document.getElementById('btn-add-formation');
+  if (addBtn) addBtn.onclick = () => openFormationModal();
+}
+
+function renderFormations() {
+  const container = document.querySelector('#liste .cards-container');
+  if (!container) return;
+  container.innerHTML = formations.map(f => formationCard(f)).join('');
+  container.querySelectorAll('.btn-edit-formation').forEach(btn => {
+    btn.onclick = () => {
+      const formation = formations.find(f => f.id === btn.dataset.id);
+      if (formation) openFormationModal(formation);
+    };
+  });
+  updateCount();
+}
+
+function formationCard(f) {
+  return `
+    <div class="card mission-card" data-id="${f.id}">
+      <div class="card-header">
+        <div class="mission-header-content">
+          <h3 class="card-title">${f.nom}</h3>
+          <span class="badge badge-warning">${f.id}</span>
+        </div>
+      </div>
+      <div class="card-content">
+        <div class="mission-info">
+          <div class="info-row"><span class="info-label">Description :</span><span class="info-value description-text">${f.description || ''}</span></div>
+        </div>
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-sm btn-edit-formation" data-id="${f.id}"><i class="fas fa-edit"></i> Modifier</button>
+      </div>
+    </div>`;
+}
+
+function updateCount() {
+  const el = document.getElementById('formations-count');
+  if (el) el.textContent = `${formations.length} formation${formations.length > 1 ? 's' : ''}`;
+}
+
+async function openFormationModal(formation = {}) {
+  const [{ FormationForm }, { GenericModal }] = await Promise.all([
+    import('../components/forms/FormationForm.js'),
+    import('../components/modals/GenericModal.js')
+  ]);
+
+  const html = GenericModal(formation.id ? 'Modifier une formation' : 'Ajouter une formation', FormationForm(formation));
+  document.body.insertAdjacentHTML('beforeend', html);
+
+  document.getElementById('close-modal').onclick = () => document.getElementById('modal-bg').remove();
+  document.getElementById('modal-bg').onclick = e => { if (e.target.id === 'modal-bg') document.getElementById('modal-bg').remove(); };
+  document.getElementById('cancel-form').onclick = () => document.getElementById('modal-bg').remove();
+
+  document.getElementById('formation-form').onsubmit = e => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const data = Object.fromEntries(fd.entries());
+    if (formation.id) {
+      const idx = formations.findIndex(f => f.id === formation.id);
+      if (idx !== -1) formations[idx] = { ...formation, ...data };
+    } else {
+      const newId = generateFormationId();
+      formations.push({ id: newId, ...data });
+    }
+    document.getElementById('modal-bg').remove();
+    showToast(formation.id ? 'Formation modifiée !' : 'Formation ajoutée !');
+    renderFormations();
+  };
+}
+
+function generateFormationId() {
+  const max = formations.reduce((acc, f) => {
+    const n = parseInt((f.id || '').replace(/\D/g, '')) || 0;
+    return n > acc ? n : acc;
+  }, 0);
+  return `F${String(max + 1).padStart(3, '0')}`;
+}
+
+export function startApp() {
+  initFormations();
+}
+
+document.addEventListener('DOMContentLoaded', startApp);

--- a/scripts/missionsManager.js
+++ b/scripts/missionsManager.js
@@ -1,1 +1,101 @@
-export function initMissions() {} 
+import { getMissions } from './dataManager.js';
+import { showToast } from '../components/Toast.js';
+
+let missions = [];
+
+export async function initMissions() {
+  try {
+    missions = await getMissions();
+  } catch (e) {
+    console.error('Erreur chargement missions', e);
+    missions = [];
+  }
+  renderMissions();
+  const addBtn = document.getElementById('btn-add-mission');
+  if (addBtn) addBtn.onclick = () => openMissionModal();
+}
+
+function renderMissions() {
+  const container = document.querySelector('#liste .cards-container');
+  if (!container) return;
+  container.innerHTML = missions.map(m => missionCard(m)).join('');
+  container.querySelectorAll('.btn-edit-mission').forEach(btn => {
+    btn.onclick = () => {
+      const mission = missions.find(m => m.id === btn.dataset.id);
+      if (mission) openMissionModal(mission);
+    };
+  });
+  updateCount();
+}
+
+function missionCard(m) {
+  const participants = (m.participants || []).join(', ');
+  return `
+    <div class="card mission-card" data-id="${m.id}">
+      <div class="card-header">
+        <div class="mission-header-content">
+          <h3 class="card-title">${m.nom}</h3>
+          <span class="badge badge-warning">${m.id}</span>
+        </div>
+        <span class="mission-status">${m.statut || ''}</span>
+      </div>
+      <div class="card-content">
+        <div class="mission-info">
+          <div class="info-row"><span class="info-label">Date:</span><span class="info-value">${m.date || ''}</span></div>
+          <div class="info-row"><span class="info-label">Participants:</span><span class="info-value">${participants}</span></div>
+        </div>
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-sm btn-edit-mission" data-id="${m.id}"><i class="fas fa-edit"></i> Modifier</button>
+      </div>
+    </div>`;
+}
+
+function updateCount() {
+  const el = document.getElementById('missions-count');
+  if (el) el.textContent = `${missions.length} mission${missions.length > 1 ? 's' : ''}`;
+}
+
+async function openMissionModal(mission = {}) {
+  const [{ MissionForm }, { GenericModal }] = await Promise.all([
+    import('../components/forms/MissionForm.js'),
+    import('../components/modals/GenericModal.js')
+  ]);
+
+  const html = GenericModal(mission.id ? 'Modifier une mission' : 'Ajouter une mission', MissionForm(mission));
+  document.body.insertAdjacentHTML('beforeend', html);
+
+  document.getElementById('close-modal').onclick = () => document.getElementById('modal-bg').remove();
+  document.getElementById('modal-bg').onclick = e => { if (e.target.id === 'modal-bg') document.getElementById('modal-bg').remove(); };
+  document.getElementById('cancel-form').onclick = () => document.getElementById('modal-bg').remove();
+
+  document.getElementById('mission-form').onsubmit = e => {
+    e.preventDefault();
+    const fd = new FormData(e.target);
+    const data = Object.fromEntries(fd.entries());
+    if (mission.id) {
+      const idx = missions.findIndex(m => m.id === mission.id);
+      if (idx !== -1) missions[idx] = { ...mission, ...data };
+    } else {
+      const newId = generateMissionId();
+      missions.push({ id: newId, ...data });
+    }
+    document.getElementById('modal-bg').remove();
+    showToast(mission.id ? 'Mission modifiée !' : 'Mission ajoutée !');
+    renderMissions();
+  };
+}
+
+function generateMissionId() {
+  const max = missions.reduce((acc, m) => {
+    const n = parseInt((m.id || '').replace(/\D/g, '')) || 0;
+    return n > acc ? n : acc;
+  }, 0);
+  return `M${String(max + 1).padStart(3, '0')}`;
+}
+
+export function startApp() {
+  initMissions();
+}
+
+document.addEventListener('DOMContentLoaded', startApp);


### PR DESCRIPTION
## Summary
- build mission manager to list, create and edit missions
- build formation manager with similar features
- new managers hook into pageManager to initialize on page load

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6843f54b707c832886417e1748a58308