### PR TITLE
Implement API data manager

### DIFF
--- a/scripts/dataManager.js
+++ b/scripts/dataManager.js
@@ -1,39 +1,122 @@
-// dataManager.js — version statique pour GitHub Pages
+// dataManager.js — utilisation de l'API Express
+
+async function handleResponse(res, errorMsg) {
+  if (!res.ok) {
+    const msg = await res.text().catch(() => '');
+    throw new Error(`${errorMsg} (${res.status}) ${msg}`.trim());
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
 
 export async function getSoldats() {
-  const res = await fetch('data/test/soldats.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des soldats');
-  return await res.json();
+  const res = await fetch('/api/soldats');
+  return handleResponse(res, 'Erreur lors de la récupération des soldats');
 }
 
 export async function getUnites() {
-  const res = await fetch('data/test/unites.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des unités');
-  return await res.json();
+  const res = await fetch('/api/unites');
+  return handleResponse(res, 'Erreur lors de la récupération des unités');
 }
 
 export async function getMissions() {
-  const res = await fetch('data/test/missions.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des missions');
-  return await res.json();
+  const res = await fetch('/api/missions');
+  return handleResponse(res, 'Erreur lors de la récupération des missions');
 }
 
 export async function getFormations() {
-  const res = await fetch('data/test/formations.json');
-  if (!res.ok) throw new Error('Erreur lors de la récupération des formations');
-  return await res.json();
+  const res = await fetch('/api/formations');
+  return handleResponse(res, 'Erreur lors de la récupération des formations');
 }
 
-// Les fonctions de création, modification, suppression ne font rien en statique
-export async function createSoldat() { throw new Error('Non supporté en statique'); }
-export async function updateSoldat() { throw new Error('Non supporté en statique'); }
-export async function deleteSoldat() { throw new Error('Non supporté en statique'); }
-export async function createUnite() { throw new Error('Non supporté en statique'); }
-export async function updateUnite() { throw new Error('Non supporté en statique'); }
-export async function deleteUnite() { throw new Error('Non supporté en statique'); }
-export async function createMission() { throw new Error('Non supporté en statique'); }
-export async function updateMission() { throw new Error('Non supporté en statique'); }
-export async function deleteMission() { throw new Error('Non supporté en statique'); }
-export async function createFormation() { throw new Error('Non supporté en statique'); }
-export async function updateFormation() { throw new Error('Non supporté en statique'); }
-export async function deleteFormation() { throw new Error('Non supporté en statique'); }
+export async function createSoldat(data) {
+  const res = await fetch('/api/soldats', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la création du soldat');
+}
+
+export async function updateSoldat(id, data) {
+  const res = await fetch(`/api/soldats/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la mise à jour du soldat');
+}
+
+export async function deleteSoldat(id) {
+  const res = await fetch(`/api/soldats/${id}`, { method: 'DELETE' });
+  return handleResponse(res, 'Erreur lors de la suppression du soldat');
+}
+
+export async function createUnite(data) {
+  const res = await fetch('/api/unites', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, "Erreur lors de la création de l'unité");
+}
+
+export async function updateUnite(id, data) {
+  const res = await fetch(`/api/unites/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, "Erreur lors de la mise à jour de l'unité");
+}
+
+export async function deleteUnite(id) {
+  const res = await fetch(`/api/unites/${id}`, { method: 'DELETE' });
+  return handleResponse(res, "Erreur lors de la suppression de l'unité");
+}
+
+export async function createMission(data) {
+  const res = await fetch('/api/missions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la création de la mission');
+}
+
+export async function updateMission(id, data) {
+  const res = await fetch(`/api/missions/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la mise à jour de la mission');
+}
+
+export async function deleteMission(id) {
+  const res = await fetch(`/api/missions/${id}`, { method: 'DELETE' });
+  return handleResponse(res, 'Erreur lors de la suppression de la mission');
+}
+
+export async function createFormation(data) {
+  const res = await fetch('/api/formations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la création de la formation');
+}
+
+export async function updateFormation(id, data) {
+  const res = await fetch(`/api/formations/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  return handleResponse(res, 'Erreur lors de la mise à jour de la formation');
+}
+
+export async function deleteFormation(id) {
+  const res = await fetch(`/api/formations/${id}`, { method: 'DELETE' });
+  return handleResponse(res, 'Erreur lors de la suppression de la formation');
+}

--- a/scripts/displayManager.js
+++ b/scripts/displayManager.js
@@ -1,17 +1,16 @@
 // Gestion de l’affichage dynamique (dashboard, alertes, etc.)
-import { fetchData } from './utils.js';
-import { getData, setData, addItem, updateItem, deleteItem } from './dataManager.js';
 import { showToast } from '../components/Toast.js';
+import { getSoldats, getUnites, getMissions, getFormations, createSoldat, createUnite, createMission, createFormation } from './dataManager.js';
 
 /**
  * Affiche le dashboard dynamique dans #app-root
  */
 export async function displayDashboard() {
   try {
-    const soldats = getData('soldats');
-    const unites = getData('unites');
-    const missions = getData('missions');
-    const formations = getData('formations');
+    const soldats = await getSoldats();
+    const unites = await getUnites();
+    const missions = await getMissions();
+    const formations = await getFormations();
     // Stats
     const totalSoldats = soldats.length;
     const totalRecrues = soldats.filter(s => s.grade.toLowerCase().includes('recrue')).length;
@@ -141,10 +140,18 @@ export async function displayDashboard() {
             if(data.faits_d_armes) data.faits_d_armes = data.faits_d_armes.split(',').map(s=>s.trim()).filter(Boolean);
             if(data.recompenses) data.recompenses = data.recompenses.split(',').map(s=>s.trim()).filter(Boolean);
             data.missions_effectuees = parseInt(data.missions_effectuees)||0;
-            addItem('soldats', data);
-            document.getElementById('modal-bg').remove();
-            showToast('Soldat ajouté !');
-            displaySoldats();
+            createSoldat(data)
+              .then(() => {
+                showToast('Soldat ajouté !');
+                displaySoldats();
+              })
+              .catch(err => {
+                console.error(err);
+                showToast('Erreur lors de la création', 'error');
+              })
+              .finally(() => {
+                document.getElementById('modal-bg').remove();
+              });
           };
         });
       });
@@ -163,10 +170,18 @@ export async function displayDashboard() {
             const fd = new FormData(e.target);
             const data = Object.fromEntries(fd.entries());
             if(data.occupants) data.occupants = data.occupants.split(',').map(s=>s.trim()).filter(Boolean);
-            addItem('unites', data);
-            document.getElementById('modal-bg').remove();
-            showToast('Unité ajoutée !');
-            displayUnites();
+            createUnite(data)
+              .then(() => {
+                showToast('Unité ajoutée !');
+                displayUnites();
+              })
+              .catch(err => {
+                console.error(err);
+                showToast('Erreur création unité', 'error');
+              })
+              .finally(() => {
+                document.getElementById('modal-bg').remove();
+              });
           };
         });
       });
@@ -184,10 +199,18 @@ export async function displayDashboard() {
             e.preventDefault();
             const fd = new FormData(e.target);
             const data = Object.fromEntries(fd.entries());
-            addItem('missions', data);
-            document.getElementById('modal-bg').remove();
-            showToast('Mission ajoutée !');
-            displayMissions();
+            createMission(data)
+              .then(() => {
+                showToast('Mission ajoutée !');
+                displayMissions();
+              })
+              .catch(err => {
+                console.error(err);
+                showToast('Erreur création mission', 'error');
+              })
+              .finally(() => {
+                document.getElementById('modal-bg').remove();
+              });
           };
         });
       });
@@ -205,8 +228,17 @@ export async function displayDashboard() {
             e.preventDefault();
             const fd = new FormData(e.target);
             const data = Object.fromEntries(fd.entries());
-            console.log('[AJOUT FORMATION]', data); // Prêt pour intégration backend
-            document.getElementById('modal-bg').remove();
+            createFormation(data)
+              .then(() => {
+                showToast('Formation ajoutée !');
+              })
+              .catch(err => {
+                console.error(err);
+                showToast('Erreur création formation', 'error');
+              })
+              .finally(() => {
+                document.getElementById('modal-bg').remove();
+              });
           };
         });
       });

--- a/scripts/soldatsManager.js
+++ b/scripts/soldatsManager.js
@@ -1,4 +1,6 @@
 import { showModal } from './utils.js';
+import { createSoldat } from './dataManager.js';
+import { showToast } from '../components/Toast.js';
 
 export function initSoldats() {
   // Sélectionne tous les boutons Détails
@@ -384,11 +386,15 @@ export function startApp() {
           if(data.faits_d_armes) data.faits_d_armes = data.faits_d_armes.split(',').map(s=>s.trim()).filter(Boolean);
           if(data.recompenses) data.recompenses = data.recompenses.split(',').map(s=>s.trim()).filter(Boolean);
           data.missions_effectuees = parseInt(data.missions_effectuees)||0;
-          addItem('soldats', data);
-          document.getElementById('modal-bg').remove();
-          showToast('Soldat ajouté !');
-          // Recharger la liste des soldats
-          initSoldats();
+          createSoldat(data).then(() => {
+            showToast('Soldat ajouté !');
+            initSoldats();
+          }).catch(err => {
+            console.error(err);
+            showToast('Erreur lors de la création', 'error');
+          }).finally(() => {
+            document.getElementById('modal-bg').remove();
+          });
         };
       });
     });


### PR DESCRIPTION
## Summary
- connect dataManager.js to Express API
- use API methods when submitting forms
- wire soldiers manager to createSoldat
- fetch dashboard data from API instead of local storage

## Testing
- `npm install`
- `npm start` *(fails here because we killed the server after verifying startup)*

------
https://chatgpt.com/codex/tasks/task_e_6843f54c18648328bf194a18a2f2655e