### PR TITLE
Improve unit navigation and live search

### DIFF
--- a/data/api/unites.json
+++ b/data/api/unites.json
@@ -1,8 +1,18 @@
 [
   {
+    "id": "EGC-HQ",
+    "nom": "Eagle Company",
+    "type": "HQ",
+    "children": ["UNT-001", "UNT-002"],
+    "membres": [],
+    "createdAt": "2024-01-01T00:00:00.000Z",
+    "updatedAt": "2024-01-01T00:00:00.000Z"
+  },
+  {
     "id": "UNT-001",
     "nom": "Alpha 1-1",
-    "type": "Unité tactique",
+    "type": "SQUAD",
+    "parent": "EGC-HQ",
     "chef": "EGC-001",
     "membres": ["EGC-001", "EGC-002", "EGC-003"],
     "specialite": "Opérations spéciales",
@@ -15,7 +25,8 @@
   {
     "id": "UNT-002",
     "nom": "Bravo 2-1",
-    "type": "Unité de support",
+    "type": "SQUAD",
+    "parent": "EGC-HQ",
     "chef": "EGC-004",
     "membres": ["EGC-004", "EGC-005", "EGC-006"],
     "specialite": "Logistique et support",
@@ -25,4 +36,4 @@
     "createdAt": "2024-01-15T00:00:00.000Z",
     "updatedAt": "2024-01-15T00:00:00.000Z"
   }
-] 
+]

--- a/pages/unites.html
+++ b/pages/unites.html
@@ -27,188 +27,19 @@
           <span id="unites-count" class="badge badge-warning">5 unités</span>
         </div>
       </div>
+
+      <nav id="breadcrumb" class="breadcrumb"></nav>
       
       <!-- Structure hiérarchique des unités -->
       <section class="unites-section" id="arbre">
         <h2><i class="fas fa-sitemap"></i> Structure des unités</h2>
-        <div class="unit-tree">
-          <!-- Unité principale -->
-          <div class="unit-node unit-hq">
-            <div class="unit-header">
-              <div class="unit-toggle"><i class="fas fa-chevron-down"></i></div>
-              <div class="unit-icon"><i class="fas fa-star"></i></div>
-              <div class="unit-info">
-                <h3>Eagle Company</h3>
-                <div class="unit-meta">
-                  <span class="unit-id">EGC-HQ</span>
-                  <span class="unit-count">32 soldats</span>
-                </div>
-              </div>
-              <div class="unit-actions">
-                <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-              </div>
-            </div>
-            
-            <div class="unit-children">
-              <!-- Sous-unité 1 -->
-              <div class="unit-node">
-                <div class="unit-header">
-                  <div class="unit-toggle"><i class="fas fa-chevron-down"></i></div>
-                  <div class="unit-icon"><i class="fas fa-shield-alt"></i></div>
-                  <div class="unit-info">
-                    <h3>Alpha Squad</h3>
-                    <div class="unit-meta">
-                      <span class="unit-id">EGC-A</span>
-                      <span class="unit-count">12 soldats</span>
-                    </div>
-                  </div>
-                  <div class="unit-actions">
-                    <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-                  </div>
-                </div>
-                
-                <div class="unit-children">
-                  <!-- Sous-unité 1.1 -->
-                  <div class="unit-node">
-                    <div class="unit-header">
-                      <div class="unit-toggle"><i class="fas fa-chevron-right"></i></div>
-                      <div class="unit-icon"><i class="fas fa-users"></i></div>
-                      <div class="unit-info">
-                        <h3>Alpha 1-1</h3>
-                        <div class="unit-meta">
-                          <span class="unit-id">EGC-A11</span>
-                          <span class="unit-count">4 soldats</span>
-                        </div>
-                      </div>
-                      <div class="unit-actions">
-                        <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                        <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  <!-- Sous-unité 1.2 -->
-                  <div class="unit-node">
-                    <div class="unit-header">
-                      <div class="unit-toggle"><i class="fas fa-chevron-right"></i></div>
-                      <div class="unit-icon"><i class="fas fa-users"></i></div>
-                      <div class="unit-info">
-                        <h3>Alpha 1-2</h3>
-                        <div class="unit-meta">
-                          <span class="unit-id">EGC-A12</span>
-                          <span class="unit-count">4 soldats</span>
-                        </div>
-                      </div>
-                      <div class="unit-actions">
-                        <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                        <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              
-              <!-- Sous-unité 2 -->
-              <div class="unit-node">
-                <div class="unit-header">
-                  <div class="unit-toggle"><i class="fas fa-chevron-right"></i></div>
-                  <div class="unit-icon"><i class="fas fa-shield-alt"></i></div>
-                  <div class="unit-info">
-                    <h3>Bravo Squad</h3>
-                    <div class="unit-meta">
-                      <span class="unit-id">EGC-B</span>
-                      <span class="unit-count">10 soldats</span>
-                    </div>
-                  </div>
-                  <div class="unit-actions">
-                    <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-                  </div>
-                </div>
-              </div>
-              
-              <!-- Sous-unité 3 -->
-              <div class="unit-node">
-                <div class="unit-header">
-                  <div class="unit-toggle"><i class="fas fa-chevron-right"></i></div>
-                  <div class="unit-icon"><i class="fas fa-shield-alt"></i></div>
-                  <div class="unit-info">
-                    <h3>Charlie Squad</h3>
-                    <div class="unit-meta">
-                      <span class="unit-id">EGC-C</span>
-                      <span class="unit-count">10 soldats</span>
-                    </div>
-                  </div>
-                  <div class="unit-actions">
-                    <button class="btn btn-sm" title="Voir les détails"><i class="fas fa-eye"></i></button>
-                    <button class="btn btn-sm" title="Modifier l'unité"><i class="fas fa-edit"></i></button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div class="unit-tree"></div>
       </section>
       
       <!-- Détails de l'unité -->
       <section class="unites-section" id="details-unite">
         <h2><i class="fas fa-info-circle"></i> Détails de l'unité</h2>
-        <div class="unit-details">
-          <div class="unit-card">
-            <div class="unit-card-header">
-              <h3>Alpha 1-1</h3>
-              <span class="badge badge-warning">EGC-A11</span>
-            </div>
-            <div class="unit-card-content">
-              <div class="unit-stats">
-                <div class="stat-item">
-                  <div class="stat-value">4</div>
-                  <div class="stat-label">Soldats</div>
-                </div>
-                <div class="stat-item">
-                  <div class="stat-value">12</div>
-                  <div class="stat-label">Missions</div>
-                </div>
-                <div class="stat-item">
-                  <div class="stat-value">3</div>
-                  <div class="stat-label">Formations</div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="unit-card">
-            <div class="unit-card-header">
-              <h3>Membres</h3>
-            </div>
-            <div class="unit-card-content">
-              <ul class="members-list">
-                <li>
-                  <span class="member-name">ICEMAN</span>
-                  <span class="member-grade">Caporal-chef</span>
-                  <span class="member-role">Chef d'unité</span>
-                </li>
-                <li>
-                  <span class="member-name">FURY</span>
-                  <span class="member-grade">Caporal</span>
-                  <span class="member-role">Opérateur</span>
-                </li>
-                <li>
-                  <span class="member-name">OLIVE</span>
-                  <span class="member-grade">Soldat Première Classe</span>
-                  <span class="member-role">Opérateur</span>
-                </li>
-                <li>
-                  <span class="member-name">RECRUE1</span>
-                  <span class="member-grade">Recrue</span>
-                  <span class="member-role">En formation</span>
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
+        <div id="unite-details" class="unit-details"></div>
       </section>
       </div>
     </div>

--- a/scripts/soldatsManager.js
+++ b/scripts/soldatsManager.js
@@ -433,7 +433,7 @@ function initFilters() {
     btnReset.onclick = resetFilters;
   }
   
-  [filterStatus, filterUnite, filterGrade, searchInput].forEach(el => {
+  [filterStatus, filterUnite, filterGrade].forEach(el => {
     if (el) {
       el.onchange = applyFilters;
     } else {
@@ -441,14 +441,14 @@ function initFilters() {
     }
   });
 
-  // Add event listener for 'Enter' key on search input
   if (searchInput) {
-      searchInput.addEventListener('keypress', function(event) {
-          if (event.key === 'Enter') {
-              event.preventDefault(); // Prevent default form submission
-              applyFilters();
-          }
-      });
+    searchInput.addEventListener('input', applyFilters);
+    searchInput.addEventListener('keypress', function(event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        applyFilters();
+      }
+    });
   }
 }
 

--- a/scripts/unitesManager.js
+++ b/scripts/unitesManager.js
@@ -32,6 +32,9 @@ function renderUniteTree() {
     if (hqUnit) {
         const hqNode = createUniteNode(hqUnit);
         treeContainer.appendChild(hqNode);
+        selectedUnite = hqUnit;
+        updateSelectedNode(hqNode);
+        renderUniteDetails(hqUnit);
     }
 
     const searchInput = document.getElementById('search-unite');
@@ -91,9 +94,19 @@ function createUniteNode(unite) {
             const children = node.querySelector('.unit-children');
             if (children) {
                 children.style.display = children.style.display === 'none' ? 'block' : 'none';
-                toggle.querySelector('i').className = 
+                toggle.querySelector('i').className =
                     children.style.display === 'none' ? 'fas fa-chevron-right' : 'fas fa-chevron-down';
             }
+        });
+    }
+
+    // Sélection de l'unité au clic sur l'en-tête
+    const header = node.querySelector('.unit-header');
+    if (header) {
+        header.addEventListener('click', () => {
+            selectedUnite = unite;
+            updateSelectedNode(node);
+            renderUniteDetails(unite);
         });
     }
 
@@ -116,6 +129,58 @@ function updateUnitesCount() {
     if (countElement) {
         countElement.textContent = `${unites.length} unités`;
     }
+}
+
+function updateSelectedNode(node) {
+    document.querySelectorAll('.unit-selected').forEach(n => n.classList.remove('unit-selected'));
+    node.classList.add('unit-selected');
+}
+
+function updateBreadcrumb(unite) {
+    const breadcrumbEl = document.getElementById('breadcrumb');
+    if (!breadcrumbEl) return;
+    const path = [];
+    let current = unite;
+    while (current) {
+        path.unshift(current.nom);
+        current = current.parent ? unites.find(u => u.id === current.parent) : null;
+    }
+    breadcrumbEl.textContent = path.join(' > ');
+}
+
+function renderUniteDetails(unite) {
+    const container = document.getElementById('unite-details');
+    if (!container) return;
+    container.innerHTML = `
+        <div class="unit-card">
+            <div class="unit-card-header">
+                <h3>${unite.nom}</h3>
+                <span class="badge badge-warning">${unite.id}</span>
+            </div>
+            <div class="unit-card-content">
+                <div class="unit-stats">
+                    <div class="stat-item">
+                        <div class="stat-value">${unite.membres?.length || 0}</div>
+                        <div class="stat-label">Soldats</div>
+                    </div>
+                    <div class="stat-item">
+                        <div class="stat-value">${unite.missions?.length || 0}</div>
+                        <div class="stat-label">Missions</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="unit-card">
+            <div class="unit-card-header">
+                <h3>Membres</h3>
+            </div>
+            <div class="unit-card-content">
+                <ul class="members-list">
+                    ${unite.membres?.map(m => `<li>${m}</li>`).join('') || '<li>Aucun membre</li>'}
+                </ul>
+            </div>
+        </div>`;
+    updateBreadcrumb(unite);
 }
 
 // Filtrer l'arbre des unités selon la recherche

--- a/styles/global.css
+++ b/styles/global.css
@@ -1073,3 +1073,14 @@ input:focus, select:focus, textarea:focus {
   color: var(--gold);
   border-radius: 3px;
 }
+
+/* Breadcrumb navigation */
+.breadcrumb {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+/* Highlight selected unit */
+.unit-selected > .unit-header {
+  background-color: rgba(255, 191, 0, 0.2);
+}


### PR DESCRIPTION
## Summary
- add parent/children hierarchy to `unites.json`
- inject breadcrumb and dynamic details container in units page
- highlight selected unit and style breadcrumb
- render selected unit details on click and show breadcrumb path
- make soldiers search filter while typing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684400d3b7a0832892fe21ec072c8208