### PR TITLE
Add disciplinary reports API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Plateforme de Commandement et de Gestion RP pour la Eagle Company.
 - Utilisez `env.js` pour basculer entre TEST et PROD
 - Dépendances : Tailwind CSS, Wind.js
 
+## Nouvelles fonctionnalités
+
+Un endpoint `/api/reports` permet maintenant d'enregistrer des rapports
+disciplinaires ou d'évaluation. Les données sont stockées dans
+`data/api/reports.json`.
+
 ## Structure
 
 Voir le cahier des charges pour l’arborescence complète.

--- a/data/api/reports.json
+++ b/data/api/reports.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "REP-001",
+    "soldatId": "EGC-001",
+    "type": "avertissement",
+    "message": "Retard à la formation tactique",
+    "date": "2024-05-01T00:00:00.000Z",
+    "superieur": "CAP-001"
+  }
+]

--- a/routes/reports.js
+++ b/routes/reports.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs').promises;
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, '../data/api/reports.json');
+
+async function readData() {
+  try {
+    const data = await fs.readFile(DATA_FILE, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      await fs.writeFile(DATA_FILE, JSON.stringify([]));
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function writeData(data) {
+  await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+// GET /api/reports
+router.get('/', async (req, res) => {
+  try {
+    const reports = await readData();
+    res.json(reports);
+  } catch (error) {
+    res.status(500).json({ error: "Erreur lors de la lecture des rapports" });
+  }
+});
+
+// POST /api/reports
+router.post('/', async (req, res) => {
+  try {
+    const reports = await readData();
+    const newReport = {
+      id: `REP-${String(reports.length + 1).padStart(3, '0')}`,
+      ...req.body,
+      createdAt: new Date().toISOString()
+    };
+    reports.push(newReport);
+    await writeData(reports);
+    res.status(201).json(newReport);
+  } catch (error) {
+    res.status(500).json({ error: "Erreur lors de la création du rapport" });
+  }
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -23,12 +23,14 @@ const missionsRouter = require('./routes/missions');
 const formationsRouter = require('./routes/formations');
 const unitesRouter = require('./routes/unites');
 const alertsRouter = require('./routes/alerts');
+const reportsRouter = require('./routes/reports');
 
 app.use('/api/soldats', soldatsRouter);
 app.use('/api/missions', missionsRouter);
 app.use('/api/formations', formationsRouter);
 app.use('/api/unites', unitesRouter);
 app.use('/api/alerts', alertsRouter);
+app.use('/api/reports', reportsRouter);
 
 // Route racine
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- implement `/api/reports` endpoint with simple CRUD
- store reports in `data/api/reports.json`
- expose new route from server
- document the feature in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68440bf18bd883288b369d0c898984c6